### PR TITLE
Get list of device before run task, not before configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   ext {
     this_groupId = 'ae.vigilancer.gradle.plugin'
     this_artifactId = 'android-run'
-    this_version = '1.2.0'
+    this_version = '1.2.1'
     this_url = 'https://github.com/vigilancer/android-app-run-gradle-plugin'
     this_vcsUrl = 'https://github.com/vigilancer/android-app-run-gradle-plugin.git'
     this_description = 'Build, install and run any BuildVariant of Android application with one command'

--- a/src/main/kotlin/ae/vigilancer/gradle/plugin/android/run/AppRunnerPlugin.kt
+++ b/src/main/kotlin/ae/vigilancer/gradle/plugin/android/run/AppRunnerPlugin.kt
@@ -26,10 +26,11 @@ class AppRunnerPlugin : Plugin<Project> {
         project.extensions.create("appRunner", AppRunnerExtension::class.java)
         val ext: AppExtension = project.extensions.getByType(AppExtension::class.java)
         val adb = ext.adbExe
-        val deviceProvider: DeviceProvider = ConnectedDeviceProvider(adb, 2000, StdLogger(StdLogger.Level.VERBOSE));
-        deviceProvider.init()
 
         ext.applicationVariants.all { variant ->
+            val deviceProvider: DeviceProvider = ConnectedDeviceProvider(adb, 2000, StdLogger(StdLogger.Level.VERBOSE));
+            deviceProvider.init()
+
             // skipping unsigned non-debug builds since they don't have 'Install*' tasks
             if (!variant.isSigningReady)
                 return@all


### PR DESCRIPTION
Getting the list of devices on configuration phase has some issues:
- On slow builds (like mine) device configuration could be changed
- Slower configuration phase.
- If the connection fails, gradle went down too:

![image](https://cloud.githubusercontent.com/assets/38703/21799150/bcaabecc-d720-11e6-9d4d-3a78310046ee.png)

